### PR TITLE
Update stored rotation values on setRotationOffset

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -177,6 +177,9 @@ pAttach = {
         local ped = self.instances[element]
         local ins = self.pedInstances[ped].list[element]
 
+        ins.rx = x or 0
+        ins.ry = y or 0
+        ins.rz = z or 0
         ins.rotMat = self:calculateRotMat(x or 0, y or 0, z or 0)
         return true
     end,


### PR DESCRIPTION
The old rotation values should be updated with the new values after they have been changed by setRotationOffset. This way getDetails will return correct data.